### PR TITLE
Added vni 2 to the test vpc1

### DIFF
--- a/test_vpc1.yaml
+++ b/test_vpc1.yaml
@@ -24,6 +24,7 @@ kind: Vpc
 metadata:
   name: vpc1
 spec:
+  vni: 2
   ip: "192.168.0.0"
   prefix: "16"
   status: "Init"


### PR DESCRIPTION
We used to set vni 2 by default when the new vpc's name is "vpc1". 

Since we enabled vpc customization so that we can configure vni, we updated the test vpc yaml as well.