### PR TITLE
Install go in the master node to build mizar cni

### DIFF
--- a/install_go.sh
+++ b/install_go.sh
@@ -1,0 +1,13 @@
+
+#!/bin/bash
+
+# Install go and related
+cd /tmp; wget https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf go1.13.9.linux-amd64.tar.gz
+rm -rf go1.13.9.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+sudo apt-get install -y protobuf-compiler libprotobuf-dev
+GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
+GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
+GO111MODULE="on" go get github.com/smartystreets/goconvey@v1.6.7
+

--- a/install_go.sh
+++ b/install_go.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 # Install go and related

--- a/install_go.sh
+++ b/install_go.sh
@@ -8,5 +8,5 @@ export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
 sudo apt-get install -y protobuf-compiler libprotobuf-dev
 GO111MODULE="on" go get google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 GO111MODULE="on" go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
-GO111MODULE="on" go get github.com/smartystreets/goconvey@v1.6.7
+GO111MODULE="on" go get github.com/smartystreets/goconvey@v1.6.4
 

--- a/node_setup_master.sh
+++ b/node_setup_master.sh
@@ -48,3 +48,5 @@ EOF
 
 apt-get install -y build-essential clang-7 llvm-7 libelf-dev python3.8 python3-pip libcmocka-dev lcov python3.8-dev python3-apt pkg-config
 python3 -m pip install --user grpcio-tools
+
+sh ./install_go.sh


### PR DESCRIPTION
The change is to adopt the PR at https://github.com/CentaurusInfra/mizar/pull/526/ which is to build mizar cni using go instead of python. 

Ran the "node_setup_master.sh" and you will see the output like
```bash
Saving to: ‘go1.13.9.linux-amd64.tar.gz’

go1.13.9.linux-amd64.tar.gz                                 100%[========================================================================================================================================>] 114.57M  46.8MB/s    in 2.4s

2021-11-29 21:10:57 (46.8 MB/s) - ‘go1.13.9.linux-amd64.tar.gz’ saved [120139686/120139686]

Reading package lists... Done
Building dependency tree
Reading state information... Done
libprotobuf-dev is already the newest version (3.0.0-9.1ubuntu1).
protobuf-compiler is already the newest version (3.0.0-9.1ubuntu1).
0 upgraded, 0 newly installed, 0 to remove and 100 not upgraded.
go: finding github.com v1.6.7
go: finding github.com/smartystreets v1.6.7
```
And then run "go version" to make it sure that go1.13.9 has been installed.
```bash
root@ip-172-31-2-32:~/mizar_cluster_scripts# go version
go version go1.13.9 linux/amd64
```