### PR TITLE
Added install_python.sh to install python3.7.12

### DIFF
--- a/install_python.sh
+++ b/install_python.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Install python 3.7.12 since apt install always install python3.7.4
+sudo apt update -y
+sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev
+
+sudo apt-get remove -y --purge python3.7
+
+cd /tmp; 
+wget https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz
+tar -xf Python-3.7.12.tgz
+rm -rf Python-3.7.12.tgz
+cd Python-3.7.12
+./configure --enable-optimizations
+sudo make install
+python3 --version

--- a/install_python.sh
+++ b/install_python.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
+PYTHON_VERSION=${PYTHON_VERSION:-"3.7.12"}
 
-# Install python 3.7.12 since apt install always install python3.7.4
+# Install python 3.7.12 since apt install always install python3.7.5
 sudo apt update -y
 sudo apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev
 
 sudo apt-get remove -y --purge python3.7
 
 cd /tmp; 
-wget https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz
-tar -xf Python-3.7.12.tgz
-rm -rf Python-3.7.12.tgz
-cd Python-3.7.12
+wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+tar -xf Python-${PYTHON_VERSION}.tgz
+rm -rf Python-${PYTHON_VERSION}.tgz
+cd Python-${PYTHON_VERSION}
 ./configure --enable-optimizations
 sudo make install
 python3 --version

--- a/node_setup_master.sh
+++ b/node_setup_master.sh
@@ -50,3 +50,4 @@ apt-get install -y build-essential clang-7 llvm-7 libelf-dev python3.8 python3-p
 python3 -m pip install --user grpcio-tools
 
 sh ./install_go.sh
+sh ./install_python.sh

--- a/node_setup_master.sh
+++ b/node_setup_master.sh
@@ -50,4 +50,3 @@ apt-get install -y build-essential clang-7 llvm-7 libelf-dev python3.8 python3-p
 python3 -m pip install --user grpcio-tools
 
 sh ./install_go.sh
-sh ./install_python.sh

--- a/node_setup_slave.sh
+++ b/node_setup_slave.sh
@@ -48,3 +48,5 @@ cat <<EOF | sudo tee /etc/cni/net.d/10-mizarcni.conf
         "type": "mizarcni"
 }
 EOF
+
+sh ./install_python.sh


### PR DESCRIPTION
The current apt install does install python3.7.5 instead. When you try to run " pip3 install --ignore-installed /var/mizar/" and you will get the following errors. After updating it to python3.7.12 by using "./install_python.sh" or specify its version by using "PYTHON_VERSION=3.7.12 ./install_python.sh", it does not have the issue.

```bash
 ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-1kiaty80/luigi_caa626ef89c0459587459eae17fb793e/setup.py'"'"'; __file__='"'"'/tmp/pip-install-1kiaty80/luigi_caa626ef89c0459587459eae17fb793e/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-x5c3ajjo
       cwd: /tmp/pip-install-1kiaty80/luigi_caa626ef89c0459587459eae17fb793e/
  Complete output (26 lines):
  running egg_info
  creating /tmp/pip-pip-egg-info-x5c3ajjo/luigi.egg-info
  writing /tmp/pip-pip-egg-info-x5c3ajjo/luigi.egg-info/PKG-INFO
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-1kiaty80/luigi_caa626ef89c0459587459eae17fb793e/setup.py", line 121, in <module>
      'Topic :: System :: Monitoring',
    File "/usr/local/lib/python3.7/dist-packages/setuptools/__init__.py", line 153, in setup
      return distutils.core.setup(**attrs)
    File "/usr/lib/python3.7/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.7/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.7/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/usr/local/lib/python3.7/dist-packages/setuptools/command/egg_info.py", line 292, in run
      writer(self, ep.name, os.path.join(self.egg_info, ep.name))
    File "/usr/local/lib/python3.7/dist-packages/setuptools/command/egg_info.py", line 656, in write_pkg_info
      metadata.write_pkg_info(cmd.egg_info)
    File "/usr/lib/python3.7/distutils/dist.py", line 1117, in write_pkg_info
      self.write_pkg_file(pkg_info)
    File "/usr/local/lib/python3.7/dist-packages/setuptools/dist.py", line 167, in write_pkg_file
      write_field('Summary', single_line(self.get_description()))
    File "/usr/local/lib/python3.7/dist-packages/setuptools/dist.py", line 151, in single_line
      raise ValueError('Newlines are not allowed')
  ValueError: Newlines are not allowed
  ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/e0/f8/3173a260cee500a10aa1e0bc4c2f25349891c0ef602573833d1460cebc2e/luigi-2.8.12.tar.gz#sha256=b6dfef1b4cfb821e9bcd7ecdcb8cf9ced35aa2e4475f54d411bbf0a371af03dd (from https://pypi.org/simple/luigi/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement luigi==2.8.12 (from mizar) (from versions: 1.0.9.macosx-10.7-intel, 1.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 1.0.7, 1.0.9, 1.0.10, 1.0.11, 1.0.12, 1.0.13, 1.0.14, 1.0.15, 1.0.16, 1.0.17, 1.0.18, 1.0.19, 1.0.20, 1.0.22, 1.0.23, 1.0.24, 1.1.0, 1.1.1, 1.1.2, 1.2.1, 1.3.0, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.2.0, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.4.0, 2.5.0, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.7.1, 2.7.2, 2.7.3, 2.7.4, 2.7.5, 2.7.6, 2.7.7, 2.7.8, 2.7.9, 2.8.0, 2.8.1, 2.8.2, 2.8.3, 2.8.4, 2.8.5, 2.8.6, 2.8.7, 2.8.8, 2.8.9, 2.8.10, 2.8.11, 2.8.12, 2.8.13, 3.0.0b1, 3.0.0b2, 3.0.0, 3.0.1, 3.0.2, 3.0.3)
ERROR: No matching distribution found for luigi==2.8.12
```

